### PR TITLE
Fix position: sticky for left side navigation

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -75,7 +75,7 @@
             <div class="container mx-auto leading-normal">
                 <div class="flex flex-wrap">
                     <div id="menu" class="w-full bg-black mb-8 md:bg-transparent md:w-1/3 px-4 py-8 md:px-10 md:py-32">
-                        <nav class="leading-tight md:border-grey-light md:border-r md:py-4 sticky">
+                        <nav class="leading-tight md:border-grey-light md:border-r md:py-4 sticky pin-t">
                             <h5 class="text-sm text-grey-dark mb-2">INTRODUCTION</h5>
                             <ul class="list-reset mb-8">
                                 <li class="mb-2">


### PR DESCRIPTION
Added `pin-t` class to stick the navigation to the top of the page when scrolling.